### PR TITLE
非同期処理が有効になっている場合にまれにファイル読み込みに失敗する現象を修正

### DIFF
--- a/Dev/EffekseerForDXLib/EffekseerForDXLib.cpp
+++ b/Dev/EffekseerForDXLib/EffekseerForDXLib.cpp
@@ -167,6 +167,11 @@ public:
 	{
 		auto path_ = ToMulti((wchar_t*)path);
 
+		const auto useASyncLoadFlag = GetUseASyncLoadFlag();
+		if (useASyncLoadFlag)
+		{
+			SetUseASyncLoadFlag(false);
+		}
 		auto fileHandle = g_openFunc(path_.c_str());
 
 		if (fileHandle == 0)
@@ -175,11 +180,7 @@ public:
 		auto size = g_readSizeFunc(path_.c_str());
 		std::vector<uint8_t> data;
 		data.resize(static_cast<size_t>(size));
-		const auto useASyncLoadFlag = GetUseASyncLoadFlag();
-		if (useASyncLoadFlag)
-		{
-			SetUseASyncLoadFlag(false);
-		}
+
 		FileRead_read(data.data(), static_cast<int>(size), fileHandle);
 		FileRead_close(fileHandle);
 		if (useASyncLoadFlag)


### PR DESCRIPTION
ファイルオープン時に非同期処理が有効になっている場合、まれに読み込み前に非同期処理を解除しても失敗するため
ファイルオープン時より前に非同期処理を切るように変更しました