### PR TITLE
DX_NON_DIRECT3D11とDX_NON_DIRECT3D9オプション有効時、ビルドエラーが発生する

### DIFF
--- a/Dev/EffekseerForDXLib/EffekseerForDXLib.cpp
+++ b/Dev/EffekseerForDXLib/EffekseerForDXLib.cpp
@@ -203,7 +203,7 @@ static bool CopyRenderTargetToBackground()
 
 	LPDIRECT3DDEVICE9 device = (LPDIRECT3DDEVICE9)GetUseDirect3DDevice9();
 	if (device == NULL)
-		return nullptr;
+		return false;
 
 	HRESULT hr;
 	IDirect3DSurface9* tempRender = nullptr;
@@ -221,19 +221,21 @@ static bool CopyRenderTargetToBackground()
 		goto Exit;
 	}
 
-	device->SetRenderTarget(0, g_dx9_backgroundSurface);
-	device->SetDepthStencilSurface(nullptr);
+	{
+		device->SetRenderTarget(0, g_dx9_backgroundSurface);
+		device->SetDepthStencilSurface(nullptr);
 
-	D3DSURFACE_DESC desc;
-	tempRender->GetDesc(&desc);
-	const bool isSame = (desc.Width == g_backgroundWidth && desc.Height == g_backgroundHeight);
+		D3DSURFACE_DESC desc;
+		tempRender->GetDesc(&desc);
+		const bool isSame = (desc.Width == g_backgroundWidth && desc.Height == g_backgroundHeight);
 
-	device->StretchRect(tempRender, nullptr, g_dx9_backgroundSurface, nullptr, (isSame ? D3DTEXF_POINT : D3DTEXF_LINEAR));
+		device->StretchRect(tempRender, nullptr, g_dx9_backgroundSurface, nullptr, (isSame ? D3DTEXF_POINT : D3DTEXF_LINEAR));
 
-	device->SetRenderTarget(0, tempRender);
-	device->SetDepthStencilSurface(tempDepth);
+		device->SetRenderTarget(0, tempRender);
+		device->SetDepthStencilSurface(tempDepth);
 
-	ret = true;
+		ret = true;
+	}
 
 Exit:;
 	ES_SAFE_RELEASE(tempRender);
@@ -297,9 +299,9 @@ bool PrepareTexture_DX11(uint32_t width, uint32_t height, DXGI_FORMAT format)
 
 static void Effekseer_Distort()
 {
-	LPDIRECT3DDEVICE9 dx9_device = (LPDIRECT3DDEVICE9)GetUseDirect3DDevice9();
-	ID3D11Device* dx11_device = (ID3D11Device*)GetUseDirect3D11Device();
-	ID3D11DeviceContext* dx11_device_context = (ID3D11DeviceContext*)GetUseDirect3D11DeviceContext();
+	LPDIRECT3DDEVICE9 dx9_device = __Effekseer_DxLib_GetDirect3DDevice9();
+	ID3D11Device* dx11_device = __Effekseer_DxLib_GetDirect3DDevice11();
+	ID3D11DeviceContext* dx11_device_context = __Effekseer_DxLib_Get3D11DeviceContext();
 
 	if (dx9_device != nullptr)
 	{
@@ -483,9 +485,9 @@ int Effekseer_InitDistortion(float scale)
 	sizeX = static_cast<int32_t>(sizeX * scale);
 	sizeY = static_cast<int32_t>(sizeY * scale);
 
-	LPDIRECT3DDEVICE9 dx9_device = (LPDIRECT3DDEVICE9)GetUseDirect3DDevice9();
-	ID3D11Device* dx11_device = (ID3D11Device*)GetUseDirect3D11Device();
-	ID3D11DeviceContext* dx11_device_context = (ID3D11DeviceContext*)GetUseDirect3D11DeviceContext();
+	LPDIRECT3DDEVICE9 dx9_device = __Effekseer_DxLib_GetDirect3DDevice9();
+	ID3D11Device* dx11_device = __Effekseer_DxLib_GetDirect3DDevice11();
+	ID3D11DeviceContext* dx11_device_context = __Effekseer_DxLib_Get3D11DeviceContext();
 
 	if (dx9_device != NULL)
 	{

--- a/Dev/EffekseerForDXLib/EffekseerForDXLib.cpp
+++ b/Dev/EffekseerForDXLib/EffekseerForDXLib.cpp
@@ -91,7 +91,7 @@ static bool AllocateBackgroundBuffer(int32_t sizeX, int32_t sizeY)
 		return false;
 	}
 
-	LPDIRECT3DDEVICE9 dx9_device = (LPDIRECT3DDEVICE9)GetUseDirect3DDevice9();
+	LPDIRECT3DDEVICE9 dx9_device = __Effekseer_DxLib_GetDirect3DDevice9();
 
 	if (dx9_device != NULL)
 	{
@@ -201,7 +201,7 @@ static bool CopyRenderTargetToBackground()
 
 	bool ret = false;
 
-	LPDIRECT3DDEVICE9 device = (LPDIRECT3DDEVICE9)GetUseDirect3DDevice9();
+	LPDIRECT3DDEVICE9 device = __Effekseer_DxLib_GetDirect3DDevice9();
 	if (device == NULL)
 		return false;
 
@@ -246,7 +246,7 @@ Exit:;
 
 bool PrepareTexture_DX11(uint32_t width, uint32_t height, DXGI_FORMAT format)
 {
-	ID3D11Device* dx11_device = (ID3D11Device*)GetUseDirect3D11Device();
+	ID3D11Device* dx11_device = __Effekseer_DxLib_GetDirect3DDevice11();
 	if (dx11_device == nullptr)
 		return false;
 
@@ -305,7 +305,7 @@ static void Effekseer_Distort()
 
 	if (dx9_device != nullptr)
 	{
-		if (GetUseDirect3DDevice9() == NULL)
+		if (__Effekseer_DxLib_GetDirect3DDevice9() == NULL)
 			return;
 		auto renderer2d = (EffekseerRendererDX9::Renderer*)g_renderer2d.Get();
 		auto renderer3d = (EffekseerRendererDX9::Renderer*)g_renderer3d.Get();
@@ -391,9 +391,9 @@ int Effekseer_Init(int particleMax, EffekseerFileOpenFunc openFunc, EffekseerFil
 
 int Effkseer_Init(int particleMax, EffekseerFileOpenFunc openFunc, EffekseerFileReadSizeFunc readSizeFunc)
 {
-	LPDIRECT3DDEVICE9 dx9_device = (LPDIRECT3DDEVICE9)GetUseDirect3DDevice9();
-	ID3D11Device* dx11_device = (ID3D11Device*)GetUseDirect3D11Device();
-	ID3D11DeviceContext* dx11_device_context = (ID3D11DeviceContext*)GetUseDirect3D11DeviceContext();
+	LPDIRECT3DDEVICE9 dx9_device = __Effekseer_DxLib_GetDirect3DDevice9();
+	ID3D11Device* dx11_device = __Effekseer_DxLib_GetDirect3DDevice11();
+	ID3D11DeviceContext* dx11_device_context = __Effekseer_DxLib_Get3D11DeviceContext();
 
 	if (dx9_device == NULL && dx11_device == NULL)
 		return -1;
@@ -1153,7 +1153,7 @@ int DrawEffekseer3D_End()
 
 void Effkseer_DeviceLost(void* data)
 {
-	if (GetUseDirect3DDevice9() == NULL)
+	if (__Effekseer_DxLib_GetDirect3DDevice9() == NULL)
 		return;
 
 	g_renderer2d->SetBackground(nullptr);
@@ -1181,11 +1181,11 @@ void Effkseer_DeviceLost(void* data)
 
 void Effkseer_DeviceRestore(void* data)
 {
-	if (GetUseDirect3DDevice9() == NULL)
+	if (__Effekseer_DxLib_GetDirect3DDevice9() == NULL)
 		return;
 
 	// DXライブラリは回復時に内部でデバイスを再生成するので新しく設定する。
-	LPDIRECT3DDEVICE9 device = (LPDIRECT3DDEVICE9)GetUseDirect3DDevice9();
+	LPDIRECT3DDEVICE9 device = __Effekseer_DxLib_GetDirect3DDevice9();
 
 	auto renderer2d = (EffekseerRendererDX9::Renderer*)g_renderer2d.Get();
 	auto renderer3d = (EffekseerRendererDX9::Renderer*)g_renderer3d.Get();

--- a/Dev/EffekseerForDXLib/EffekseerForDXLib.h
+++ b/Dev/EffekseerForDXLib/EffekseerForDXLib.h
@@ -1,6 +1,4 @@
-﻿
-#pragma once
-
+﻿#pragma once
 #include "DxLib.h"
 #include "Effekseer.h"
 #include "EffekseerRendererDX11.h"
@@ -179,6 +177,31 @@ inline int __Effekseer_FileRead_open(const char* filePath) { return FileRead_ope
 
 inline LONGLONG __Effekseer_FileRead_size(const char* FilePath) { return FileRead_size(FilePath); }
 #endif
+
+inline LPDIRECT3DDEVICE9 __Effekseer_DxLib_GetDirect3DDevice9() { 
+#ifndef DX_NON_DIRECT3D9
+	return (LPDIRECT3DDEVICE9)GetUseDirect3DDevice9();
+#else // DX_NON_DIRECT3D9
+	return NULL;
+#endif
+}
+
+inline ID3D11Device* __Effekseer_DxLib_GetDirect3DDevice11() { 
+#ifndef DX_NON_DIRECT3D11
+	return (ID3D11Device*)GetUseDirect3D11Device();
+#else // DX_NON_DIRECT3D11
+	return NULL:
+#endif
+} 
+
+inline ID3D11DeviceContext* __Effekseer_DxLib_Get3D11DeviceContext()
+{
+#ifndef DX_NON_DIRECT3D11
+	return (ID3D11DeviceContext*)GetUseDirect3D11DeviceContext();
+#else // DX_NON_DIRECT3D11
+	return NULL:
+#endif
+}
 
 typedef int (*EffekseerFileOpenFunc)(const char* filePath);
 typedef LONGLONG (*EffekseerFileReadSizeFunc)(const char* filePath);

--- a/Dev/EffekseerForDXLib/EffekseerForDXLib_vs2022.vcxproj
+++ b/Dev/EffekseerForDXLib/EffekseerForDXLib_vs2022.vcxproj
@@ -94,6 +94,7 @@
       <AdditionalIncludeDirectories>..\include\</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PreprocessorDefinitions>_EFFEKSEER_FOR_DXLIB_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -107,6 +108,7 @@
       <AdditionalIncludeDirectories>..\include\</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PreprocessorDefinitions>_EFFEKSEER_FOR_DXLIB_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -123,6 +125,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PreprocessorDefinitions>_EFFEKSEER_FOR_DXLIB_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WholeProgramOptimization>false</WholeProgramOptimization>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -140,6 +143,7 @@
       <AdditionalIncludeDirectories>..\include\</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PreprocessorDefinitions>_EFFEKSEER_FOR_DXLIB_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/Dev/Sample/Sample_vs2022.vcxproj
+++ b/Dev/Sample/Sample_vs2022.vcxproj
@@ -85,6 +85,7 @@
       <SDLCheck>true</SDLCheck>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalIncludeDirectories>..\include\;..\EffekseerForDXLib\</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -98,6 +99,7 @@
       <SDLCheck>true</SDLCheck>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalIncludeDirectories>..\include\;..\EffekseerForDXLib\</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -114,6 +116,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalIncludeDirectories>..\include\;..\EffekseerForDXLib\</AdditionalIncludeDirectories>
       <WholeProgramOptimization>false</WholeProgramOptimization>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -131,6 +134,7 @@
       <SDLCheck>true</SDLCheck>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalIncludeDirectories>..\include\;..\EffekseerForDXLib\</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
・DxCompileConfig.h内にあるDX_NON_DIRECT3D11とDX_NON_DIRECT3D9オプションを有効にした場合
ビルド出来ない現象を修正
・visual studio2022においてstd::variantを使用するためプロジェクトプロパティをC++17に変更 
・CopyRenderTargetToBackground内においてD3D9DeviceがNULLの場合異なる型を返す部分を修正